### PR TITLE
Laravel 5.4 Compatibility Update

### DIFF
--- a/src/Beaudierman/Ups/UpsServiceProvider.php
+++ b/src/Beaudierman/Ups/UpsServiceProvider.php
@@ -28,7 +28,7 @@ class UpsServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['ups'] = $this->app->share(function($app)
+		$this->app['ups'] = $this->app->singleton('ups', function($app)
 		{
 			return new Ups;
 		});


### PR DESCRIPTION
5.4 removed the share method used in older versions of the framework.